### PR TITLE
cheri: Derive to-be-modified caps from pcc/almighty instead of the cap table

### DIFF
--- a/FreeRTOS/Source/portable/GCC/RISC-V/port.c
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/port.c
@@ -196,7 +196,8 @@ void *pvReturnSealer;
 		               __CHERI_CAP_PERMISSION_PERMIT_LOAD_CAPABILITY__);
 
 	pvReturnSealer = cheri_setaddress( pvAlmightyDataCap, SANDBOX_RETURN_OTYPE );
-	pxPortSandboxReturnFunc = cheri_seal( xPortSandboxReturn, pvReturnSealer );
+	pxPortSandboxReturnFunc = cheri_setaddress( pvAlmightyCodeCap, ( ptraddr_t )  xPortSandboxReturn );
+	pxPortSandboxReturnFunc = cheri_seal( pxPortSandboxReturnFunc, pvReturnSealer );
 	pxPortSandboxReturnData = cheri_seal( pvAlmightyDataCap, pvReturnSealer );
 }
 #endif

--- a/FreeRTOS/Source/portable/GCC/RISC-V/port.c
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/port.c
@@ -188,18 +188,7 @@ extern void ( * pxPortSandboxGetReturnTrampoline( void ) ) ( void );
 extern void xPortSandboxReturn( BaseType_t xReturn );
 void *pvReturnSealer;
 
-	/* pxPortSandboxReturnTrampoline will be assigned an unsealed/non-sentry as
-	pxPortSandboxGetReturnTrampoline() needs to modify it setting its bounds
-	and we set its permissions here. */
-	pxPortSandboxReturnTrampoline =
-		cheri_andperm( pxPortSandboxGetReturnTrampoline(),
-		               __CHERI_CAP_PERMISSION_GLOBAL__ |
-		               __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__ |
-		               __CHERI_CAP_PERMISSION_PERMIT_LOAD__ |
-		               __CHERI_CAP_PERMISSION_PERMIT_LOAD_CAPABILITY__);
-
-	/* sealentry again after setting bounds and permissions to avoid leaking a non-sentry. */
-	pxPortSandboxReturnTrampoline = __builtin_cheri_seal_entry( pxPortSandboxReturnTrampoline );
+	pxPortSandboxReturnTrampoline = pxPortSandboxGetReturnTrampoline();
 
 	pvReturnSealer = cheri_setaddress( pvAlmightyDataCap, SANDBOX_RETURN_OTYPE );
 	pxPortSandboxReturnFunc = cheri_setaddress( pvAlmightyCodeCap, ( ptraddr_t )  xPortSandboxReturn );

--- a/FreeRTOS/Source/portable/GCC/RISC-V/port.c
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/port.c
@@ -188,12 +188,18 @@ extern void ( * pxPortSandboxGetReturnTrampoline( void ) ) ( void );
 extern void xPortSandboxReturn( BaseType_t xReturn );
 void *pvReturnSealer;
 
+	/* pxPortSandboxReturnTrampoline will be assigned an unsealed/non-sentry as
+	pxPortSandboxGetReturnTrampoline() needs to modify it setting its bounds
+	and we set its permissions here. */
 	pxPortSandboxReturnTrampoline =
 		cheri_andperm( pxPortSandboxGetReturnTrampoline(),
 		               __CHERI_CAP_PERMISSION_GLOBAL__ |
 		               __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__ |
 		               __CHERI_CAP_PERMISSION_PERMIT_LOAD__ |
 		               __CHERI_CAP_PERMISSION_PERMIT_LOAD_CAPABILITY__);
+
+	/* sealentry again after setting bounds and permissions to avoid leaking a non-sentry. */
+	pxPortSandboxReturnTrampoline = __builtin_cheri_seal_entry( pxPortSandboxReturnTrampoline );
 
 	pvReturnSealer = cheri_setaddress( pvAlmightyDataCap, SANDBOX_RETURN_OTYPE );
 	pxPortSandboxReturnFunc = cheri_setaddress( pvAlmightyCodeCap, ( ptraddr_t )  xPortSandboxReturn );

--- a/FreeRTOS/Source/portable/GCC/RISC-V/portASM.S
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/portASM.S
@@ -957,7 +957,7 @@ xPortSandboxReturnTrampoline:
 .align 4
 .type pxPortSandboxGetReturnTrampoline, %function
 pxPortSandboxGetReturnTrampoline:
-	clgc              ca0, xPortSandboxReturnTrampoline
+	cllc              ca0, xPortSandboxReturnTrampoline
 	li                a1, %lo(.LxPortSandboxReturnTrampolineEnd - xPortSandboxReturnTrampoline)
 	csetboundsexact   ca0, ca0, a1
 	cret

--- a/FreeRTOS/Source/portable/GCC/RISC-V/portASM.S
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/portASM.S
@@ -957,9 +957,23 @@ xPortSandboxReturnTrampoline:
 .align 4
 .type pxPortSandboxGetReturnTrampoline, %function
 pxPortSandboxGetReturnTrampoline:
+	/* Load a PCC-derived unsealed (non-sentry) cap to xPortSandboxReturnTrampoline */
 	cllc              ca0, xPortSandboxReturnTrampoline
+
+	/* Set bounds */
 	li                a1, %lo(.LxPortSandboxReturnTrampolineEnd - xPortSandboxReturnTrampoline)
 	csetboundsexact   ca0, ca0, a1
+
+	/* Set permissions */
+	li                t1, __CHERI_CAP_PERMISSION_GLOBAL__ | \
+		                __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__ | \
+		                __CHERI_CAP_PERMISSION_PERMIT_LOAD__ | \
+		                __CHERI_CAP_PERMISSION_PERMIT_LOAD_CAPABILITY__
+	candperm          ca0, ca0, t1
+
+	/* sealentry after setting bounds and permissions to avoid leaking a non-sentry. */
+	csealentry        ca0, ca0
+
 	cret
 .size pxPortSandboxGetReturnTrampoline, . - pxPortSandboxGetReturnTrampoline
 


### PR DESCRIPTION

With the addition of sentries, all functions are now sealed entries. Hence,
the code that now tries to seal them or setbounds on them faults. Deriving
from the unsealed PCC/almighty code cap makes them unsealed and able to be
modified/resealed with a generic OTYPE for sandboxing.