### PR TITLE
modbus: restoration of tcp client/server comms

### DIFF
--- a/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/include/microbenchmark.h
+++ b/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/include/microbenchmark.h
@@ -34,7 +34,7 @@
 #define MAX_FUNCTIONS 20
 
 /* number of iterations of each function to be sampled and recorded */
-#define MICROBENCHMARK_ITERATIONS 100
+#define MICROBENCHMARK_ITERATIONS 10
 
 /* number of iterations to discard to ensure quiescense */
 #define MICROBENCHMARK_DISCARD 10

--- a/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/include/modbus_client.h
+++ b/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/include/modbus_client.h
@@ -38,8 +38,5 @@ void vClientTask(void *pvParameters);
  * Called by main_modbus() to initialise the client before
  * creating tasks and starting the scheduler
  */
-void vClientInitialization(char *ip, int port,
-                             QueueHandle_t xQueueRequest,
-                             QueueHandle_t xQueueResponse);
-
+void vClientInitialization(char *ip, int port);
 #endif /* _MODBUS_CLIENT_H_ */

--- a/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/include/modbus_demo.h
+++ b/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/include/modbus_demo.h
@@ -21,8 +21,8 @@
  ***************/
 
 /* Priorities used by the tasks. */
-#define mainCLIENT_TASK_PRIORITY (tskIDLE_PRIORITY + 1)
-#define mainSERVER_TASK_PRIORITY (tskIDLE_PRIORITY + 2)
+#define modbusCLIENT_TASK_PRIORITY (tskIDLE_PRIORITY)
+#define modbusSERVER_TASK_PRIORITY (tskIDLE_PRIORITY + 1)
 
 /* The maximum number items the queue can hold.  The priority of the receiving
 task is above the priority of the sending task, so the receiving task will
@@ -30,15 +30,25 @@ preempt the sending task and remove the queue items each time the sending task
 writes to the queue.  Therefore the queue will never have more than one item in
 it at any time, and even with a queue length of 1, the sending task will never
 find the queue full. */
-#define mainQUEUE_LENGTH (1)
+#define modbusQUEUE_LENGTH (1)
 
-/* The rate at which data is sent to the queue.  The 200ms value is converted
-to ticks using the pdMS_TO_TICKS() macro. */
-#define mainQUEUE_SEND_FREQUENCY_MS pdMS_TO_TICKS(200)
+/* The rate at which data is sent from the client to the server.
+ * The 200ms value is converted to ticks using the pdMS_TO_TICKS() macro. */
+#define modbusCLIENT_SEND_FREQUENCY_MS pdMS_TO_TICKS(200)
+
+/* Set a 100ms loop tiem for the server */
+#define modbusSERVER_LOOP_TIME pdMS_TO_TICKS(100)
 
 /******************
  * TYPE DEFINITIONS
  *****************/
+
+/* structure to hold queue messages (requests and responses) */
+typedef struct _queue_msg_t
+{
+    int msg_length;
+    uint8_t *msg;
+} queue_msg_t;
 
 /******************
  * HELPER FUNCTIONS

--- a/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/include/modbus_server.h
+++ b/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/include/modbus_server.h
@@ -29,7 +29,7 @@
 #define _MODBUS_SERVER_H_
 
 /* priority for tasks initialised by the server task */
-#define prvCRITICAL_SECTION_TASK_PRIORITY (tskIDLE_PRIORITY + 3)
+#define prvCRITICAL_SECTION_TASK_PRIORITY (tskIDLE_PRIORITY + 2)
 
 /*
  * Receives a modbus request from a client and
@@ -41,7 +41,5 @@ void vServerTask(void *pvParameters);
  * Called by main_modbus() to initialise the server before
  * creating tasks and starting the scheduler
  */
-void vServerInitialization(char *ip, int port,
-                             QueueHandle_t xQueueRequest,
-                             QueueHandle_t xQueueResponse);
+void vServerInitialization(char *ip, int port);
 #endif /* _MODBUS_SERVER_H_ */

--- a/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/modbus_client.c
+++ b/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/modbus_client.c
@@ -65,62 +65,53 @@
 
 /*-----------------------------------------------------------*/
 
+/* Closes the connection, frees memory, and deletes the task */
+static void prvClientTaskShutdown(void);
+
 /* Helper function for converting to libmodbus formats */
 static int convert_string_req(const char *req_string, uint8_t *req);
 
 /*-----------------------------------------------------------*/
 
-/* The structure holding connection information. */
+/* libmodbus variables */
 static modbus_t *ctx = NULL;
-
-#if defined(MACAROONS_LAYER)
-/* The queue used to communicate Macaroons from client to server. */
-extern QueueHandle_t xQueueClientServerMacaroons;
-
-/* The queue used to communicate Macaroons from server to client. */
-extern QueueHandle_t xQueueServerClientMacaroons;
-#endif
+static uint8_t *tab_rp_bits = NULL;
+static uint16_t *tab_rp_registers = NULL;
+static uint8_t *tab_rp_string = NULL;
 
 /*-----------------------------------------------------------*/
 
-void vClientInitialization(char *ip, int port,
-                             QueueHandle_t xQueueClientServer,
-                             QueueHandle_t xQueueServerClient)
+void vClientInitialization(char *ip, int port)
 {
-  /* initialise the connection */
-  ctx = modbus_new_tcp(ip, port);
-  if (ctx == NULL)
-  {
-    fprintf(stderr, "Failed to allocate ctx: %s\n",
-            modbus_strerror(errno));
-    modbus_free(ctx);
-    _exit(0);
-  }
+    /* initialise the connection */
+    ctx = modbus_new_tcp(ip, port);
+    if (ctx == NULL)
+    {
+        fprintf(stderr, "Failed to allocate ctx: %s\n",
+                modbus_strerror(errno));
+        prvClientTaskShutdown();
+    }
 
 #ifdef NDEBUG
-  modbus_set_debug(ctx, pdFALSE);
+    modbus_set_debug(ctx, pdFALSE);
 #else
-  modbus_set_debug(ctx, pdTRUE);
+    modbus_set_debug(ctx, pdTRUE);
 #endif
 
-  modbus_set_request_queue(ctx, xQueueClientServer);
-  modbus_set_response_queue(ctx, xQueueServerClient);
-  modbus_set_server(ctx, pdFALSE);
-
 #if defined(MACAROONS_LAYER)
-  int rc;
-  /**
-   * serialise the macaroon and queue it for the client
-   *
-   * this is a TOFU operation. the first client to dequeue it gets it...
-   * */
-  rc = initialise_client_macaroon(ctx);
-  configASSERT(rc != -1);
+    int rc;
+    /**
+     * serialise the macaroon and queue it for the client
+     *
+     * this is a TOFU operation. the first client to dequeue it gets it...
+     * */
+    rc = initialise_client_macaroon(ctx);
+    configASSERT(rc != -1);
 
-  if (modbus_get_debug(ctx))
-  {
-      printf("client macaroon initialised...\n");
-  }
+    if (modbus_get_debug(ctx))
+    {
+        printf("client macaroon initialised...\n");
+    }
 #endif
 }
 
@@ -128,350 +119,372 @@ void vClientInitialization(char *ip, int port,
 
 void vClientTask(void *pvParameters)
 {
-  /* structure to hold the request and request length */
-  modbus_queue_msg_t *pxRequest = (modbus_queue_msg_t *)pvPortMalloc(sizeof(modbus_queue_msg_t));
-  pxRequest->msg = (uint8_t *)pvPortMalloc(MODBUS_MAX_STRING_LENGTH * sizeof(uint8_t));
-  memset(pxRequest->msg, 0, MODBUS_MAX_STRING_LENGTH * sizeof(uint8_t));
-  pxRequest->msg_length = 0;
+    FreeRTOS_debug_printf( ("Enter client task\n") );
 
-  /* structure to hold the response and the response length */
-  modbus_queue_msg_t *pxResponse = (modbus_queue_msg_t *)pvPortMalloc(sizeof(modbus_queue_msg_t));
-  pxResponse->msg = (uint8_t *)pvPortMalloc(MODBUS_MAX_STRING_LENGTH * sizeof(uint8_t));
-  memset(pxResponse->msg, 0, MODBUS_MAX_STRING_LENGTH * sizeof(uint8_t));
-  pxResponse->msg_length = 0;
+    TickType_t xNextWakeTime;
+    int rc;
+    int nb_points;
 
-  TickType_t xNextWakeTime;
+    /* Remove compiler warning about unused parameter. */
+    (void)pvParameters;
 
-  /* libmodbus variables */
-  int rc;
-  uint8_t *tab_rp_bits = NULL;
-  uint16_t *tab_rp_registers = NULL;
-  uint8_t *tab_rp_string = NULL;
-  int nb_points;
+    /* Initialise xNextWakeTime - this only needs to be done once. */
+    xNextWakeTime = xTaskGetTickCount();
 
-  /* Remove compiler warning about unused parameter. */
-  (void)pvParameters;
-
-  /* Initialise xNextWakeTime - this only needs to be done once. */
-  xNextWakeTime = xTaskGetTickCount();
-
-  /* Allocate and initialize the memory to store the bits */
-  nb_points = (UT_BITS_NB > UT_INPUT_BITS_NB) ? UT_BITS_NB : UT_INPUT_BITS_NB;
-  tab_rp_bits = (uint8_t *)pvPortMalloc(nb_points * sizeof(uint8_t));
-  memset(tab_rp_bits, 0, nb_points * sizeof(uint8_t));
-
-  /* Allocate and initialize the memory to store the registers */
-  nb_points = (UT_REGISTERS_NB > UT_INPUT_REGISTERS_NB) ?
-      UT_REGISTERS_NB : UT_INPUT_REGISTERS_NB;
-  tab_rp_registers = (uint16_t *) pvPortMalloc(nb_points * sizeof(uint16_t));
-  memset(tab_rp_registers, 0, nb_points * sizeof(uint16_t));
-
-  /* Allocate and initialize the memory to store the string */
-  tab_rp_string = (uint8_t *)pvPortMalloc(MODBUS_MAX_STRING_LENGTH * sizeof(uint8_t));
-  int nb_chars = convert_string_req((const char *)TEST_STRING, tab_rp_string);
-
-  printf("BEGIN_TEST\n");
-
-  /**************
-   * STRING TESTS
-   *************/
-
-  /* WRITE_STRING */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nWRITE_STRING\n");
-#endif
-
-  rc = modbus_write_string(ctx, tab_rp_string, nb_chars);
-  configASSERT(rc != -1);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* READ_STRING */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nREAD_STRING\n");
-#endif
-
-  memset(tab_rp_string, 0, MODBUS_MAX_STRING_LENGTH * sizeof(uint8_t));
-  rc = modbus_read_string(ctx, tab_rp_string);
-  configASSERT(rc != -1);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /************
-   * COIL TESTS
-   ***********/
-
-  /* WRITE_SINGLE_COIL */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nWRITE_SINGLE_COIL\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_write_bit_macaroons(ctx, UT_BITS_ADDRESS, ON);
-#else
-  rc = modbus_write_bit(ctx, UT_BITS_ADDRESS, ON);
-#endif
-  configASSERT(rc == 1);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* READ_SINGLE_COIL */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nREAD_SINGLE_COIL\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_read_bits_macaroons(ctx, UT_BITS_ADDRESS, 1, tab_rp_bits);
-#else
-  rc = modbus_read_bits(ctx, UT_BITS_ADDRESS, 1, tab_rp_bits);
-#endif
-  configASSERT(rc == 1);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* WRITE_MULTIPLE_COILS */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nWRITE_MULTIPLE_COILS\n");
-#endif
-  {
-    uint8_t tab_value[UT_BITS_NB];
-    modbus_set_bits_from_bytes(tab_value, 0, UT_BITS_NB, UT_BITS_TAB);
-
-#if defined(MACAROONS_LAYER)
-    rc = modbus_write_bits_macaroons(ctx, UT_BITS_ADDRESS, UT_BITS_NB, tab_value);
-#else
-    rc = modbus_write_bits(ctx, UT_BITS_ADDRESS, UT_BITS_NB, tab_value);
-#endif
-  }
-  configASSERT(rc == UT_BITS_NB);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* READ_MULTIPLE_COILS */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nREAD_MULTIPLE_COILS\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_read_bits_macaroons(ctx, UT_BITS_ADDRESS, UT_BITS_NB, tab_rp_bits);
-#else
-  rc = modbus_read_bits(ctx, UT_BITS_ADDRESS, UT_BITS_NB, tab_rp_bits);
-#endif
-  configASSERT(rc == UT_BITS_NB);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /**********************
-   * DISCRETE INPUT TESTS
-   *********************/
-
-  /* READ_INPUT_BITS */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nREAD_INPUT_BITS\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_read_input_bits_macaroons(ctx, UT_INPUT_BITS_ADDRESS, UT_INPUT_BITS_NB, tab_rp_bits);
-#else
-  rc = modbus_read_input_bits(ctx, UT_INPUT_BITS_ADDRESS, UT_INPUT_BITS_NB, tab_rp_bits);
-#endif
-  configASSERT(rc == UT_INPUT_BITS_NB);
-
-  {
-    /* further checks on the returned discrete inputs */
-    int idx = 0;
-    uint8_t value;
-    nb_points = UT_INPUT_BITS_NB;
-    while (nb_points > 0) {
-        int nb_bits = (nb_points > 8) ? 8 : nb_points;
-        value = modbus_get_byte_from_bits(tab_rp_bits, idx*8, nb_bits);
-        configASSERT(value == UT_INPUT_BITS_TAB[idx]);
-
-        nb_points -= nb_bits;
-        idx++;
+    /* Connect to the modbus server */
+    if(modbus_connect(ctx) == -1) {
+        fprintf(stderr, "Connection failed\n");
+        prvClientTaskShutdown();
     }
-  }
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
 
-  /************************
-   * HOLDING REGISTER TESTS
-   ***********************/
+    /* Allocate and initialize the memory to store the bits */
+    nb_points = (UT_BITS_NB > UT_INPUT_BITS_NB) ? UT_BITS_NB : UT_INPUT_BITS_NB;
+    tab_rp_bits = (uint8_t *)pvPortMalloc(nb_points * sizeof(uint8_t));
+    memset(tab_rp_bits, 0, nb_points * sizeof(uint8_t));
 
-  /* WRITE_SINGLE_REGISTER */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nWRITE_SINGLE_REGISTER\n");
-#endif
+    /* Allocate and initialize the memory to store the registers */
+    nb_points = (UT_REGISTERS_NB > UT_INPUT_REGISTERS_NB) ?
+        UT_REGISTERS_NB : UT_INPUT_REGISTERS_NB;
+    tab_rp_registers = (uint16_t *) pvPortMalloc(nb_points * sizeof(uint16_t));
+    memset(tab_rp_registers, 0, nb_points * sizeof(uint16_t));
 
-#if defined(MACAROONS_LAYER)
-  rc = modbus_write_register_macaroons(ctx, UT_REGISTERS_ADDRESS, 0x1234);
-#else
-  rc = modbus_write_register(ctx, UT_REGISTERS_ADDRESS, 0x1234);
-#endif
-  configASSERT(rc == 1);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* READ_SINGLE_REGISTER */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nREAD_SINGLE_REGISTER\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_read_registers_macaroons(ctx, UT_REGISTERS_ADDRESS, 1, tab_rp_registers);
-#else
-  rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS, 1, tab_rp_registers);
-#endif
-  configASSERT(rc == 1);
-  configASSERT(tab_rp_registers[0] == 0x1234);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* WRITE_MULTIPLE_REGISTERS */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nWRITE_MULTIPLE_REGISTERS\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_write_registers_macaroons(ctx, UT_REGISTERS_ADDRESS, UT_REGISTERS_NB, UT_REGISTERS_TAB);
-#else
-  rc = modbus_write_registers(ctx, UT_REGISTERS_ADDRESS, UT_REGISTERS_NB, UT_REGISTERS_TAB);
-#endif
-  configASSERT(rc == UT_REGISTERS_NB);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* READ_MULTIPLE_REGISTERS */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nREAD_MULTIPLE_REGISTERS\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_read_registers_macaroons(ctx, UT_REGISTERS_ADDRESS, UT_REGISTERS_NB, tab_rp_registers);
-#else
-  rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS, UT_REGISTERS_NB, tab_rp_registers);
-#endif
-  configASSERT(rc == UT_REGISTERS_NB);
-  for (int i=0; i < UT_REGISTERS_NB; i++) {
-      configASSERT(tab_rp_registers[i] == UT_REGISTERS_TAB[i]);
-  }
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* WRITE_AND_READ_REGISTERS */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nWRITE_AND_READ_REGISTERS\n");
-#endif
-
-  nb_points = (UT_REGISTERS_NB > UT_INPUT_REGISTERS_NB) ? UT_REGISTERS_NB : UT_INPUT_REGISTERS_NB;
-  memset(tab_rp_registers, 0, nb_points * sizeof(uint16_t));
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_write_and_read_registers_macaroons(ctx,
-                                                 UT_REGISTERS_ADDRESS + 1,
-                                                 UT_REGISTERS_NB - 1,
-                                                 tab_rp_registers,
-                                                 UT_REGISTERS_ADDRESS,
-                                                 UT_REGISTERS_NB,
-                                                 tab_rp_registers);
-#else
-  rc = modbus_write_and_read_registers(ctx,
-                                       UT_REGISTERS_ADDRESS + 1,
-                                       UT_REGISTERS_NB - 1,
-                                       tab_rp_registers,
-                                       UT_REGISTERS_ADDRESS,
-                                       UT_REGISTERS_NB,
-                                       tab_rp_registers);
-#endif
-  configASSERT(rc == UT_REGISTERS_NB);
-  configASSERT(tab_rp_registers[0] == UT_REGISTERS_TAB[0]);
-  for (int i = 1; i < UT_REGISTERS_NB; i++)
-  {
-        configASSERT(tab_rp_registers[i] == 0);
-  }
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /**********************
-   * INPUT REGISTER TESTS
-   *********************/
-
-  /* READ_INPUT_REGISTERS */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nREAD_INPUT_REGISTERS\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_read_input_registers_macaroons(ctx, UT_INPUT_REGISTERS_ADDRESS,
-                                             UT_INPUT_REGISTERS_NB, tab_rp_registers);
-#else
-  rc = modbus_read_input_registers(ctx, UT_INPUT_REGISTERS_ADDRESS,
-                                   UT_INPUT_REGISTERS_NB, tab_rp_registers);
-#endif
-  configASSERT(rc == UT_INPUT_REGISTERS_NB);
-  for (int i = 0; i < UT_INPUT_REGISTERS_NB; i++)
-  {
-    configASSERT(tab_rp_registers[i] == UT_INPUT_REGISTERS_TAB[i]);
-  }
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /*****************************
-   * HOLDING REGISTER MASK TESTS
-   ****************************/
-
-  /* WRITE_SINGLE_REGISTER */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nWRITE_SINGLE_REGISTER\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_write_register_macaroons(ctx, UT_REGISTERS_ADDRESS, 0x12);
-#else
-  rc = modbus_write_register(ctx, UT_REGISTERS_ADDRESS, 0x12);
-#endif
-  configASSERT(rc == 1);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* MASK_WRITE_SINGLE_REGISTER */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nMASK_WRITE_SINGLE_REGISTER\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_mask_write_register_macaroons(ctx, UT_REGISTERS_ADDRESS, 0xF2, 0x25);
-#else
-  rc = modbus_mask_write_register(ctx, UT_REGISTERS_ADDRESS, 0xF2, 0x25);
-#endif
-  configASSERT(rc != -1);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
-
-  /* READ_SINGLE_REGISTER */
-#ifndef NDEBUG
-  print_shim_info("modbus_client", __FUNCTION__);
-  printf("\nREAD_SINGLE_REGISTER\n");
-#endif
-
-#if defined(MACAROONS_LAYER)
-  rc = modbus_read_registers_macaroons(ctx, UT_REGISTERS_ADDRESS, 1, tab_rp_registers);
-#else
-  rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS, 1, tab_rp_registers);
-#endif
-  configASSERT(rc == 1);
-  configASSERT(tab_rp_registers[0] == 0x17);
-  vTaskDelayUntil(&xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS);
+    /* Allocate and initialize the memory to store the string */
+    tab_rp_string = (uint8_t *)pvPortMalloc(MODBUS_MAX_STRING_LENGTH * sizeof(uint8_t));
+    int nb_chars = convert_string_req((const char *)TEST_STRING, tab_rp_string);
 
 #if defined(MICROBENCHMARK)
-  /* print microbenchmark samples to stdout */
-  vPrintMicrobenchmarkSamples();
+    /* If we're benchmarking, the server will be iterating over the request,
+     * so we bump up the time the client is willing to wait for a response */
+    rc = modbus_set_response_timeout(ctx, 1000, 0);
 #endif
 
-  printf("END_TEST\n");
+    printf("BEGIN_TEST\n");
 
-  /* Kill the app after the last request. */
-  _exit(0);
+    /**************
+     * STRING TESTS
+     *************/
+
+    /* WRITE_STRING */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nWRITE_STRING\n");
+#endif
+
+    rc = modbus_write_string(ctx, tab_rp_string, nb_chars);
+    configASSERT(rc != -1);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* READ_STRING */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nREAD_STRING\n");
+#endif
+
+    memset(tab_rp_string, 0, MODBUS_MAX_STRING_LENGTH * sizeof(uint8_t));
+    rc = modbus_read_string(ctx, tab_rp_string);
+    configASSERT(rc != -1);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /************
+     * COIL TESTS
+     ***********/
+
+    /* WRITE_SINGLE_COIL */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nWRITE_SINGLE_COIL\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_write_bit_macaroons(ctx, UT_BITS_ADDRESS, ON);
+#else
+    rc = modbus_write_bit(ctx, UT_BITS_ADDRESS, ON);
+#endif
+    configASSERT(rc == 1);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* READ_SINGLE_COIL */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nREAD_SINGLE_COIL\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_read_bits_macaroons(ctx, UT_BITS_ADDRESS, 1, tab_rp_bits);
+#else
+    rc = modbus_read_bits(ctx, UT_BITS_ADDRESS, 1, tab_rp_bits);
+#endif
+    configASSERT(rc == 1);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* WRITE_MULTIPLE_COILS */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nWRITE_MULTIPLE_COILS\n");
+#endif
+    {
+        uint8_t tab_value[UT_BITS_NB];
+        modbus_set_bits_from_bytes(tab_value, 0, UT_BITS_NB, UT_BITS_TAB);
+
+#if defined(MACAROONS_LAYER)
+        rc = modbus_write_bits_macaroons(ctx, UT_BITS_ADDRESS, UT_BITS_NB, tab_value);
+#else
+        rc = modbus_write_bits(ctx, UT_BITS_ADDRESS, UT_BITS_NB, tab_value);
+#endif
+    }
+    configASSERT(rc == UT_BITS_NB);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* READ_MULTIPLE_COILS */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nREAD_MULTIPLE_COILS\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_read_bits_macaroons(ctx, UT_BITS_ADDRESS, UT_BITS_NB, tab_rp_bits);
+#else
+    rc = modbus_read_bits(ctx, UT_BITS_ADDRESS, UT_BITS_NB, tab_rp_bits);
+#endif
+    configASSERT(rc == UT_BITS_NB);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /**********************
+     * DISCRETE INPUT TESTS
+     *********************/
+
+    /* READ_INPUT_BITS */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nREAD_INPUT_BITS\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_read_input_bits_macaroons(ctx, UT_INPUT_BITS_ADDRESS, UT_INPUT_BITS_NB, tab_rp_bits);
+#else
+    rc = modbus_read_input_bits(ctx, UT_INPUT_BITS_ADDRESS, UT_INPUT_BITS_NB, tab_rp_bits);
+#endif
+    configASSERT(rc == UT_INPUT_BITS_NB);
+
+    {
+        /* further checks on the returned discrete inputs */
+        int idx = 0;
+        uint8_t value;
+        nb_points = UT_INPUT_BITS_NB;
+        while (nb_points > 0) {
+            int nb_bits = (nb_points > 8) ? 8 : nb_points;
+            value = modbus_get_byte_from_bits(tab_rp_bits, idx*8, nb_bits);
+            configASSERT(value == UT_INPUT_BITS_TAB[idx]);
+
+            nb_points -= nb_bits;
+            idx++;
+        }
+    }
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /************************
+     * HOLDING REGISTER TESTS
+     ***********************/
+
+    /* WRITE_SINGLE_REGISTER */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nWRITE_SINGLE_REGISTER\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_write_register_macaroons(ctx, UT_REGISTERS_ADDRESS, 0x1234);
+#else
+    rc = modbus_write_register(ctx, UT_REGISTERS_ADDRESS, 0x1234);
+#endif
+    configASSERT(rc == 1);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* READ_SINGLE_REGISTER */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nREAD_SINGLE_REGISTER\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_read_registers_macaroons(ctx, UT_REGISTERS_ADDRESS, 1, tab_rp_registers);
+#else
+    rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS, 1, tab_rp_registers);
+#endif
+    configASSERT(rc == 1);
+    configASSERT(tab_rp_registers[0] == 0x1234);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* WRITE_MULTIPLE_REGISTERS */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nWRITE_MULTIPLE_REGISTERS\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_write_registers_macaroons(ctx, UT_REGISTERS_ADDRESS, UT_REGISTERS_NB, UT_REGISTERS_TAB);
+#else
+    rc = modbus_write_registers(ctx, UT_REGISTERS_ADDRESS, UT_REGISTERS_NB, UT_REGISTERS_TAB);
+#endif
+    configASSERT(rc == UT_REGISTERS_NB);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* READ_MULTIPLE_REGISTERS */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nREAD_MULTIPLE_REGISTERS\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_read_registers_macaroons(ctx, UT_REGISTERS_ADDRESS, UT_REGISTERS_NB, tab_rp_registers);
+#else
+    rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS, UT_REGISTERS_NB, tab_rp_registers);
+#endif
+    configASSERT(rc == UT_REGISTERS_NB);
+    for (int i=0; i < UT_REGISTERS_NB; i++) {
+        configASSERT(tab_rp_registers[i] == UT_REGISTERS_TAB[i]);
+    }
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* WRITE_AND_READ_REGISTERS */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nWRITE_AND_READ_REGISTERS\n");
+#endif
+
+    nb_points = (UT_REGISTERS_NB > UT_INPUT_REGISTERS_NB) ? UT_REGISTERS_NB : UT_INPUT_REGISTERS_NB;
+    memset(tab_rp_registers, 0, nb_points * sizeof(uint16_t));
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_write_and_read_registers_macaroons(ctx,
+            UT_REGISTERS_ADDRESS + 1,
+            UT_REGISTERS_NB - 1,
+            tab_rp_registers,
+            UT_REGISTERS_ADDRESS,
+            UT_REGISTERS_NB,
+            tab_rp_registers);
+#else
+    rc = modbus_write_and_read_registers(ctx,
+            UT_REGISTERS_ADDRESS + 1,
+            UT_REGISTERS_NB - 1,
+            tab_rp_registers,
+            UT_REGISTERS_ADDRESS,
+            UT_REGISTERS_NB,
+            tab_rp_registers);
+#endif
+    configASSERT(rc == UT_REGISTERS_NB);
+    configASSERT(tab_rp_registers[0] == UT_REGISTERS_TAB[0]);
+    for (int i = 1; i < UT_REGISTERS_NB; i++)
+    {
+        configASSERT(tab_rp_registers[i] == 0);
+    }
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /**********************
+     * INPUT REGISTER TESTS
+     *********************/
+
+    /* READ_INPUT_REGISTERS */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nREAD_INPUT_REGISTERS\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_read_input_registers_macaroons(ctx, UT_INPUT_REGISTERS_ADDRESS,
+            UT_INPUT_REGISTERS_NB, tab_rp_registers);
+#else
+    rc = modbus_read_input_registers(ctx, UT_INPUT_REGISTERS_ADDRESS,
+            UT_INPUT_REGISTERS_NB, tab_rp_registers);
+#endif
+    configASSERT(rc == UT_INPUT_REGISTERS_NB);
+    for (int i = 0; i < UT_INPUT_REGISTERS_NB; i++)
+    {
+        configASSERT(tab_rp_registers[i] == UT_INPUT_REGISTERS_TAB[i]);
+    }
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /*****************************
+     * HOLDING REGISTER MASK TESTS
+     ****************************/
+
+    /* WRITE_SINGLE_REGISTER */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nWRITE_SINGLE_REGISTER\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_write_register_macaroons(ctx, UT_REGISTERS_ADDRESS, 0x12);
+#else
+    rc = modbus_write_register(ctx, UT_REGISTERS_ADDRESS, 0x12);
+#endif
+    configASSERT(rc == 1);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* MASK_WRITE_SINGLE_REGISTER */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nMASK_WRITE_SINGLE_REGISTER\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_mask_write_register_macaroons(ctx, UT_REGISTERS_ADDRESS, 0xF2, 0x25);
+#else
+    rc = modbus_mask_write_register(ctx, UT_REGISTERS_ADDRESS, 0xF2, 0x25);
+#endif
+    configASSERT(rc != -1);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+    /* READ_SINGLE_REGISTER */
+#ifndef NDEBUG
+    print_shim_info("modbus_client", __FUNCTION__);
+    printf("\nREAD_SINGLE_REGISTER\n");
+#endif
+
+#if defined(MACAROONS_LAYER)
+    rc = modbus_read_registers_macaroons(ctx, UT_REGISTERS_ADDRESS, 1, tab_rp_registers);
+#else
+    rc = modbus_read_registers(ctx, UT_REGISTERS_ADDRESS, 1, tab_rp_registers);
+#endif
+    configASSERT(rc == 1);
+    configASSERT(tab_rp_registers[0] == 0x17);
+    //vTaskDelayUntil(&xNextWakeTime, modbusCLIENT_SEND_FREQUENCY_MS);
+
+#if defined(MICROBENCHMARK)
+    /* print microbenchmark samples to stdout */
+    vPrintMicrobenchmarkSamples();
+#endif
+
+    printf("END_TEST\n");
+
+    prvClientTaskShutdown();
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * Closes the connection, frees memory, and deletes the task
+ */
+static void prvClientTaskShutdown(void) {
+    /* close the connection to the server */
+    modbus_close(ctx);
+
+    /* free the ctx */
+    modbus_free(ctx);
+
+    /* free allocated memory */
+    vPortFree(tab_rp_bits);
+    vPortFree(tab_rp_registers);
+    vPortFree(tab_rp_string);
+
+#if defined(MICROBENCHMARK)
+    /* kill FreeRTOS execution */
+    _exit(0);
+#else
+    /* delete this task */
+    vTaskDelete(NULL);
+#endif
 }
 
 /*-----------------------------------------------------------*/
@@ -485,26 +498,26 @@ void vClientTask(void *pvParameters)
  * */
 static int convert_string_req(const char *req_string, uint8_t *req)
 {
-  int rc = -1;
-  char buf[3];
+    int rc = -1;
+    char buf[3];
 
-  if (strlen(req_string) % 4 != 0 || strlen(req_string) == 0)
-  {
-    return rc;
-  }
+    if (strlen(req_string) % 4 != 0 || strlen(req_string) == 0)
+    {
+        return rc;
+    }
 
-  /**
+    /**
      * every 4 characters in the string is one hex integer
      * i.e., "[FF]" -> 0xFF
      * */
-  for (size_t i = 0; i < (strlen(req_string)) / 4; ++i)
-  {
-    memcpy(buf, &req_string[i * 4 + 1], 2);
-    buf[2] = '\0';
-    sscanf(buf, "%hhx", &req[i]);
-  }
+    for (size_t i = 0; i < (strlen(req_string)) / 4; ++i)
+    {
+        memcpy(buf, &req_string[i * 4 + 1], 2);
+        buf[2] = '\0';
+        sscanf(buf, "%hhx", &req[i]);
+    }
 
-  req[(strlen(req_string)) / 4] = '\0';
+    req[(strlen(req_string)) / 4] = '\0';
 
-  return (strlen(req_string)) / 4 + 1;
+    return (strlen(req_string)) / 4 + 1;
 }

--- a/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/wscript
+++ b/FreeRTOS/Demo/RISC-V-Generic/modbus_demo/wscript
@@ -45,10 +45,10 @@ def configure(ctx):
 
     ctx.env.append_value('DEFINES', [
         'configPROG_ENTRY                   = main_modbus',
-        'configCUSTOM_HEAP_SIZE             = 2'
+        'configCUSTOM_HEAP_SIZE             = 2',
     ])
 
-    ctx.env.append_value('LIB_DEPS', ['freertos_tcpip'])
+    ctx.env.append_value('LIB_DEPS', ['freertos_tcpip', 'virtio'])
 
 
 def build(bld):
@@ -79,6 +79,7 @@ def build(bld):
               use=[
                   "freertos_core",
                   "freertos_bsp",
+                  "freertos_tcpip",
               ],
               target="modbus_cheri")
 
@@ -87,6 +88,7 @@ def build(bld):
               use=[
                   "freertos_core",
                   "freertos_bsp",
+                  "freertos_tcpip",
               ],
               target="modbus_macaroons")
 
@@ -111,95 +113,144 @@ def build(bld):
         target="macaroons")
 
     bld.stlib(features=['c'],
-              source=['main_modbus.c', 'modbus_server.c', 'modbus_client.c'],
-              use=[
-                  "freertos_core",
-                  "freertos_bsp",
-                  "modbus",
-              ],
-              target="modbus_baseline")
+            source=[
+                'main_modbus.c',
+                'modbus_server.c',
+                'modbus_client.c'
+            ],
+            use=[
+                "freertos_core",
+                "freertos_bsp",
+                "modbus",
+            ],
+            target="modbus_baseline")
 
     bld.stlib(features=['c'],
-              source=[
-                  'microbenchmark.c',
-              ],
-              use=[
-                  "freertos_core",
-                  "freertos_bsp",
-                  "modbus_baseline",
-              ],
-              defines=bld.env.DEFINES + ['NDEBUG=1', 'MICROBENCHMARK=1'],
-              target="modbus_baseline_microbenchmark")
+            source=[
+                'main_modbus.c',
+                'modbus_server.c',
+                'modbus_client.c',
+                'microbenchmark.c'
+            ],
+            use=[
+                "freertos_core",
+                "freertos_bsp",
+                "freertos_tcpip",
+                "modbus"
+            ],
+            defines=bld.env.DEFINES + ['NDEBUG=1', 'MICROBENCHMARK=1'],
+            target="modbus_baseline_microbenchmark")
 
     bld.stlib(features=['c'],
-              source=['main_modbus.c', 'modbus_server.c', 'modbus_client.c'],
-              use=["freertos_core", "freertos_bsp", "modbus", "modbus_cheri"],
-              defines=bld.env.DEFINES + ['NDEBUG=1', 'CHERI_LAYER=1'],
-              export_defines=['NDEBUG=1', 'CHERI_LAYER=1'],
-              target="modbus_cheri_layer")
+            source=[
+                'main_modbus.c',
+                'modbus_server.c',
+                'modbus_client.c'
+            ],
+            use=[
+                "freertos_core",
+                "freertos_bsp",
+                "modbus",
+                "modbus_cheri"
+            ],
+            defines=bld.env.DEFINES + ['CHERI_LAYER=1'],
+            target="modbus_cheri_layer")
 
     bld.stlib(features=['c'],
-              source=[
-                  'microbenchmark.c',
-              ],
-              use=[
-                  "freertos_core", "freertos_bsp", "modbus_baseline",
-                  "modbus_cheri"
-              ],
-              defines=bld.env.DEFINES +
-              ['NDEBUG=1', 'MICROBENCHMARK=1', 'CHERI_LAYER=1'],
-              export_defines=['NDEBUG=1', 'MICROBENCHMARK=1', 'CHERI_LAYER=1'],
-              target="modbus_cheri_layer_microbenchmark")
+            source=[
+                'main_modbus.c',
+                'modbus_server.c',
+                'modbus_client.c',
+                'microbenchmark.c'
+            ],
+            use=[
+                "freertos_core",
+                "freertos_bsp",
+                "modbus",
+                "modbus_cheri"
+            ],
+            defines=bld.env.DEFINES + [
+                'NDEBUG=1',
+                'CHERI_LAYER=1',
+                'MICROBENCHMARK=1'
+            ],
+            target="modbus_cheri_layer_microbenchmark")
 
     bld.stlib(features=['c'],
-              source=['main_modbus.c', 'modbus_server.c', 'modbus_client.c'],
-              use=[
-                  "freertos_core", "freertos_bsp", "modbus",
-                  "modbus_macaroons", "macaroons"
-              ],
-              defines=bld.env.DEFINES + ['MACAROONS_LAYER=1'],
-              export_defines=['MACAROONS_LAYER=1'],
-              target="modbus_macaroons_layer")
-
-    bld.stlib(
-        features=['c'],
-        source=[
-            'main_modbus.c', 'modbus_server.c', 'modbus_client.c',
-            'microbenchmark.c'
-        ],
-        use=[
-            "freertos_core", "freertos_bsp", "modbus", "modbus_macaroons",
-            "macaroons"
-        ],
-        defines=bld.env.DEFINES +
-        ['MACAROONS_LAYER=1', 'MICROBENCHMARK=1', 'NDEBUG=1'],
-        export_defines=['MACAROONS_LAYER=1', 'MICROBENCHMARK=1', 'NDEBUG=1'],
-        target="modbus_macaroons_layer_microbenchmark")
+            source=[
+                'main_modbus.c',
+                'modbus_server.c',
+                'modbus_client.c'
+            ],
+            use=[
+                "freertos_core",
+                "freertos_bsp",
+                "modbus",
+                "modbus_macaroons",
+                "macaroons"
+            ],
+            defines=bld.env.DEFINES + ['MACAROONS_LAYER=1'],
+            target="modbus_macaroons_layer")
 
     bld.stlib(features=['c'],
-              source=['main_modbus.c', 'modbus_server.c', 'modbus_client.c'],
-              use=[
-                  "freertos_core", "freertos_bsp", "modbus",
-                  "modbus_macaroons", "macaroons", "modbus_cheri"
-              ],
-              defines=bld.env.DEFINES + ['MACAROONS_LAYER=1', 'CHERI_LAYER=1'],
-              export_defines=['MACAROONS_LAYER=1', 'CHERI_LAYER=1'],
-              target="modbus_cheri_macaroons_layers")
+            source=[
+                'main_modbus.c',
+                'modbus_server.c',
+                'modbus_client.c',
+                'microbenchmark.c'
+            ],
+            use=[
+                "freertos_core",
+                "freertos_bsp",
+                "modbus",
+                "modbus_macaroons",
+                "macaroons"
+            ],
+            defines=bld.env.DEFINES + [
+                'MACAROONS_LAYER=1',
+                'MICROBENCHMARK=1',
+                'NDEBUG=1'
+            ],
+            target="modbus_macaroons_layer_microbenchmark")
 
-    bld.stlib(
-        features=['c'],
-        source=[
-            'main_modbus.c', 'modbus_server.c', 'modbus_client.c',
-            'microbenchmark.c'
-        ],
-        use=[
-            "freertos_core", "freertos_bsp", "modbus", "modbus_macaroons",
-            "macaroons", "modbus_cheri"
-        ],
-        defines=bld.env.DEFINES +
-        ['MACAROONS_LAYER=1', 'CHERI_LAYER=1', 'MICROBENCHMARK=1', 'NDEBUG=1'],
-        export_defines=[
-            'MACAROONS_LAYER=1', 'CHERI_LAYER=1', 'MICROBENCHMARK=1',
-            'NDEBUG=1'
-        ],
-        target="modbus_cheri_macaroons_layers_microbenchmark")
+    bld.stlib(features=['c'],
+            source=[
+                'main_modbus.c',
+                'modbus_server.c',
+                'modbus_client.c'
+            ],
+            use=[
+                "freertos_core",
+                "freertos_bsp",
+                "freertos_tcpip",
+                "modbus",
+                "modbus_macaroons",
+                "macaroons",
+                "modbus_cheri"
+            ],
+            defines=bld.env.DEFINES + ['MACAROONS_LAYER=1', 'CHERI_LAYER=1'],
+            target="modbus_cheri_macaroons_layers")
+
+    bld.stlib(features=['c'],
+            source=[
+                'main_modbus.c',
+                'modbus_server.c',
+                'modbus_client.c',
+                'microbenchmark.c'
+            ],
+            use=[
+                "freertos_core",
+                "freertos_bsp",
+                "freertos_tcpip",
+                "modbus",
+                "modbus_macaroons",
+                "macaroons",
+                "modbus_cheri"
+            ],
+            defines=bld.env.DEFINES + [
+                'MACAROONS_LAYER=1',
+                'CHERI_LAYER=1',
+                'MICROBENCHMARK=1',
+                'NDEBUG=1'
+            ],
+            target="modbus_cheri_macaroons_layers_microbenchmark")


### PR DESCRIPTION
Shifts back to using TCP sockets for comms between the client and server now that FreeRTOS-Plus-TCP is ported.

I had been using queues as a temporary workaround.

`modbus_baseline` and `modbus_cheri_layer` demos, along with their microbenchmark counterparts work.

Demos for macaroons don't work yet.

The `microbenchmark` demos will exit cleanly.  The non-benchmarking demos will leave the server open for external connections.